### PR TITLE
feat: Add setting to control smart tab behavior

### DIFF
--- a/ygreg/editor.py
+++ b/ygreg/editor.py
@@ -371,10 +371,14 @@ class Editor:
             self.cursor_y += 1; self.cursor_x = 0; self.modified = True
 
         elif key == '\t':
-            if self._handle_auto_expansion(): pass
-            elif self._calculate_line(): pass
-            elif self.selecting: self._indent_selection()
-            else: return self._handle_command_mode()
+            if self.settings.get("smart_tab"):
+                if self._handle_auto_expansion(): pass
+                elif self._calculate_line(): pass
+                elif self.selecting: self._indent_selection()
+                else: return self._handle_command_mode()
+            else:
+                if self.selecting: self._indent_selection()
+                else: return self._handle_command_mode()
 
         elif key == curses.KEY_BTAB:
             if self.selecting: self._unindent_selection()

--- a/ygreg/settings.py
+++ b/ygreg/settings.py
@@ -9,7 +9,8 @@ class Settings:
             "theme": "dark",
             "autosave_threshold": 25,
             "show_syntax_highlighting": True,
-            "tab_size": 4
+            "tab_size": 4,
+            "smart_tab": False
         }
         self.settings = self.defaults.copy()
         self.load()


### PR DESCRIPTION
The Tab key was previously overloaded with multiple functions (command mode, auto-expansion, calculation, indentation) which could lead to unpredictable behavior. For example, the user might expect to enter command mode, but instead trigger an auto-expansion.

This change introduces a `smart_tab` setting (defaulting to `False`) to control this behavior. When disabled, the Tab key will only trigger command mode or indent a selection, providing a more predictable experience. The "smart" features can be re-enabled by setting `smart_tab` to `true` in the configuration file.