### PR TITLE
fix: Implement context-aware Tab and fix calculation bug

### DIFF
--- a/ygreg/editor.py
+++ b/ygreg/editor.py
@@ -296,17 +296,25 @@ class Editor:
         return False
     
     def _calculate_line(self):
-        line = self.lines[self.cursor_y].split('=')[0].strip()
-        if not self.lines[self.cursor_y].strip().endswith('=') or not line: return False
+        line_content = self.lines[self.cursor_y]
+        if not line_content.strip().endswith('='):
+            return False
+
+        expression = line_content.split('=')[0].strip()
+        if not expression:
+            return False
+
         try:
             safe_env = {k: v for k, v in math.__dict__.items() if not k.startswith('_')}
-            result = eval(line, {"__builtins__": {}}, safe_env)
+            result = eval(expression, {"__builtins__": {}}, safe_env)
             result_str = str(int(result) if isinstance(result, float) and result.is_integer() else f"{result:.4f}")
             self.lines[self.cursor_y] += f" {result_str}"
             self.cursor_x = len(self.lines[self.cursor_y])
             self.modified = True
-        except Exception as e: self._set_status_message(f"Erreur de calcul: {e}")
-        return True
+            return True # Success
+        except Exception as e:
+            self._set_status_message(f"Erreur de calcul: {e}")
+            return False # Failure
 
     def _duplicate_line_or_selection(self):
         if self.selecting:


### PR DESCRIPTION
This commit delivers a complete overhaul of the Tab key's functionality based on user feedback and fixes a critical bug that was preventing command mode from triggering correctly.

The new behavior for the Tab key follows a specific priority:
1.  **Indent at Start:** If the cursor is at the beginning of a line (column 0), Tab performs a standard indentation.
2.  **Auto-expansion:** If the line contains a known trigger word (e.g., `date`) or a calculation (`=`), Tab will execute the corresponding action.
3.  **Command Mode:** If neither of the above conditions is met, Tab opens the command palette.

Additionally, a bug was fixed in the `_calculate_line` function. Previously, it would incorrectly report success even if the calculation failed (e.g., for an invalid expression like `foo=`), which would prevent the Tab key from falling back to command mode. The function now correctly returns `False` on failure.

The old `Ctrl+G` trigger has been removed, and the UI has been updated.